### PR TITLE
Support using contract address from config instead of contract address from ETHSTORAGE_MAPPING. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const {EthStorage} = require("ethstorage-sdk")
 const rpc = "https://1rpc.io/sepolia";
 const ethStorageRpc = "http://65.109.115.36:9540";
 const privateKey = "0xabcd...";
-const contractAddr = "0xabcd...";
+const address = "0xabcd..."; // EthStorage contract address
 
 const ethStorage = await EthStorage.create({
     rpc: rpc,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ const ethStorage = await EthStorage.create({
 });
 ```
 
+If you want to use your own contract, you can specify your contract address when create EthStorage.
+```js
+const {EthStorage} = require("ethstorage-sdk")
+
+const rpc = "https://1rpc.io/sepolia";
+const ethStorageRpc = "http://65.109.115.36:9540";
+const privateKey = "0xabcd...";
+const contractAddr = "0xabcd...";
+
+const ethStorage = await EthStorage.create({
+    rpc: rpc,
+    ethStorageRpc: ethStorageRpc,
+    privateKey: privateKey,
+    contractAddr: contractAddr,
+});
+```
 
 #### estimateCost
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const ethStorage = await EthStorage.create({
     rpc: rpc,
     ethStorageRpc: ethStorageRpc,
     privateKey: privateKey,
-    contractAddr: contractAddr,
+    address: address,
 });
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -81,13 +81,15 @@ The `FlatDirectory` class is a higher-level data management tool that provides m
     - `rpc` (string): RPC for any evm network.
     - `ethStorageRpc` (string): The EthStorage network rpc corresponding to this evm network, the data is obtained from the EthStorage network.
     - `privateKey` (string): Wallet private key.
+    - `address` (string, optional): your Ethstorage contract address if you want to use your own one, if you want to use the default contract address, ignore this.
 
 **Example**
 ```javascript
 const config = {
     rpc: "your_rpc",
     ethStorageRpc: "ethstorage_rpc",
-    privateKey: "your_private_key"
+    privateKey: "your_private_key",
+    address: "your_contract_address"
 };
 
 const ethStorage = await EthStorage.create(config);
@@ -381,3 +383,4 @@ const status = await flatDirectory.setDefault(defaultFile);
 ## 5. Version History
 
 - v1.0.1: Initial release with basic storage and data management functionalities.
+

--- a/src/ethstorage.js
+++ b/src/ethstorage.js
@@ -28,7 +28,7 @@ export class EthStorage {
     }
 
     constructor(config) {
-        const {rpc, ethStorageRpc, privateKey, contractAddr} = config;
+        const {rpc, ethStorageRpc, privateKey} = config;
         this.#ethStorageRpc = ethStorageRpc;
 
         const provider = new ethers.JsonRpcProvider(rpc);
@@ -38,7 +38,7 @@ export class EthStorage {
 
     async init(rpc, contractAddr) {
         const chainId = await getChainId(rpc);
-        if (!contractAddr) {
+        if (contractAddr != null) {
             this.#contractAddr = contractAddr;
         } else {
             this.#contractAddr = ETHSTORAGE_MAPPING[chainId];

--- a/src/ethstorage.js
+++ b/src/ethstorage.js
@@ -21,14 +21,14 @@ export class EthStorage {
     #blobUploader;
 
     static async create(config) {
-        const {rpc} = config;
+        const {rpc, contractAddr} = config;
         const ethStorage = new EthStorage(config);
-        await ethStorage.init(rpc);
+        await ethStorage.init(rpc, contractAddr);
         return ethStorage;
     }
 
     constructor(config) {
-        const {rpc, ethStorageRpc, privateKey} = config;
+        const {rpc, ethStorageRpc, privateKey, contractAddr} = config;
         this.#ethStorageRpc = ethStorageRpc;
 
         const provider = new ethers.JsonRpcProvider(rpc);
@@ -36,9 +36,13 @@ export class EthStorage {
         this.#blobUploader = new BlobUploader(rpc, privateKey);
     }
 
-    async init(rpc) {
+    async init(rpc, contractAddr) {
         const chainId = await getChainId(rpc);
-        this.#contractAddr = ETHSTORAGE_MAPPING[chainId];
+        if (!contractAddr) {
+            this.#contractAddr = contractAddr;
+        } else {
+            this.#contractAddr = ETHSTORAGE_MAPPING[chainId];
+        }
         if (!this.#contractAddr) {
             throw new Error("EthStorage: Network not supported yet.");
         }

--- a/src/ethstorage.js
+++ b/src/ethstorage.js
@@ -21,9 +21,9 @@ export class EthStorage {
     #blobUploader;
 
     static async create(config) {
-        const {rpc, contractAddr} = config;
+        const {rpc, address} = config;
         const ethStorage = new EthStorage(config);
-        await ethStorage.init(rpc, contractAddr);
+        await ethStorage.init(rpc, address);
         return ethStorage;
     }
 
@@ -36,9 +36,9 @@ export class EthStorage {
         this.#blobUploader = new BlobUploader(rpc, privateKey);
     }
 
-    async init(rpc, contractAddr) {
-        if (contractAddr != null) {
-            this.#contractAddr = contractAddr;
+    async init(rpc, address) {
+        if (address != null) {
+            this.#contractAddr = address;
         } else {
             const chainId = await getChainId(rpc);
             this.#contractAddr = ETHSTORAGE_MAPPING[chainId];

--- a/src/ethstorage.js
+++ b/src/ethstorage.js
@@ -37,10 +37,10 @@ export class EthStorage {
     }
 
     async init(rpc, contractAddr) {
-        const chainId = await getChainId(rpc);
         if (contractAddr != null) {
             this.#contractAddr = contractAddr;
         } else {
+            const chainId = await getChainId(rpc);
             this.#contractAddr = ETHSTORAGE_MAPPING[chainId];
         }
         if (!this.#contractAddr) {


### PR DESCRIPTION
Support using contract address from config instead of contract address from ETHSTORAGE_MAPPING. 
The integration test will use the contract address from config which was deployed in the previous step.