### PR TITLE
Part three: Get hashes in batches

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,7 @@ declare module 'ethstorage-sdk' {
       setDefault(filename: string): Promise<boolean>;
       remove(key: string): Promise<boolean>;
       download(key: string, cb: Partial<DownloadCallback>): void;
-      fetchHashes(keys: string[], concurrencyLimit?:number):Promise<any>;
+      fetchHashes(keys: string[]):Promise<any>;
       estimateCost(request: EstimateGasRequest): Promise<CostEstimate>;
       upload(request: UploadRequest): Promise<void>;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare module 'ethstorage-sdk' {
 
     // Constants
     export const BLOB_DATA_SIZE: number;
+    export const OP_BLOB_DATA_SIZE: number;
     export const BLOB_SIZE: number;
     export const MAX_BLOB_COUNT: number;
     export const PaddingPer31Bytes: number;
@@ -11,6 +12,7 @@ declare module 'ethstorage-sdk' {
     export const BLOB_COUNT_LIMIT: number;
     export const UPLOAD_TYPE_CALLDATA: number;
     export const UPLOAD_TYPE_BLOB: number;
+    export const MAX_CHUNKS: number;
 
     export const ETHSTORAGE_MAPPING: {
       [chainId: number]: string;
@@ -39,6 +41,7 @@ declare module 'ethstorage-sdk' {
         content: ContentLike,
         type: number,
         gasIncPct?: number,
+        chunkHashes?: Uint8Array[],
     }
 
     export interface UploadRequest extends EstimateGasRequest {
@@ -75,12 +78,12 @@ declare module 'ethstorage-sdk' {
 
     export class FlatDirectory {
       static create(config: SDKConfig): Promise<FlatDirectory>;
-      constructor(config: SDKConfig);
-      init(rpc: string, address?: string): Promise<void>;
+      isSupportBlob(): boolean;
       deploy(): Promise<string | null>;
       setDefault(filename: string): Promise<boolean>;
       remove(key: string): Promise<boolean>;
       download(key: string, cb: Partial<DownloadCallback>): void;
+      fetchHashes(keys: string[], concurrencyLimit?:number):Promise<any>;
       estimateCost(request: EstimateGasRequest): Promise<CostEstimate>;
       upload(request: UploadRequest): Promise<void>;
     }
@@ -101,13 +104,12 @@ declare module 'ethstorage-sdk' {
         getBlobHash(blob: Uint8Array): string;
       }
 
-      export function encodeBlobs(data: Buffer): Uint8Array[];
-      export function decodeBlob(blob: string | Uint8Array): Uint8Array;
-      export function decodeBlobs(blobs: string | Uint8Array): Buffer;
+      export function encodeOpBlobs(data: Uint8Array): Uint8Array[];
+      export function encodeOpBlob(blob: Uint8Array): Uint8Array;
 
       export function stringToHex(s: string): string;
       export function getChainId(rpc: string): Promise<number>;
-      export function getFileChunk(file: FileLike, fileSize: number, start: number, end: number): Buffer;
+      export function getContentChunk(content: ContentLike, start: number, end: number): Uint8Array;
       export function isBuffer(content: BufferLike): boolean;
       export function isFile(content: FileLike): boolean;
       export function isNodejs(): boolean;

--- a/spec.md
+++ b/spec.md
@@ -20,6 +20,7 @@
         - estimateCost
         - upload
         - download
+        - fetchHashes
         - setDefault
 - [5. Version History](#Version)
 
@@ -62,6 +63,7 @@ data of arbitrary size.
 | estimateCost | Estimate the cost of uploading data(gas cost and storage cost) |
 | upload       | Asynchronously upload data of arbitrary size                   |
 | download     | Asynchronously download data                                   |
+| fetchHashes  | Get chunk hashes of data in batches                            |
 | setDefault   | Set the default file for FlatDirectory                         |
 
 <p id="EthStorage"></p>
@@ -222,6 +224,7 @@ const address = await flatDirectory.deploy();
     - `key` (string): The key of the data.
     - `type` (number): File upload mode, 1 for calldata, 2 for blob
     - `content` (Buffer|File, optional): The content to be uploaded, which can be either a Buffer or a File.
+    - `chunkHashes` (string[], optional): The chunk hashes corresponding to the content. If this parameter exists, no request to retrieve the hashes will be triggered.
     - `gasIncPct` (number, optional): The parameter is used to specify the percentage increase on the current default
       gas. For example, if the current default gas is 100 gwei and `gasIncPct` is set to 20, then the final gas will be 120
       gwei.
@@ -282,6 +285,7 @@ console.log(`Gas Cost: ${cost.gasCost}, Storage Cost: ${cost.storageCost}`);
     - `key` (string): The key of the data.
     - `type` (number): File upload mode, 1 for calldata, 2 for blob
     - `content` (Buffer|File, optional): The content to be uploaded, which can be either a Buffer or a File.
+    - `chunkHashes` (string[], optional): The chunk hashes corresponding to the content. If this parameter exists, no request to retrieve the hashes will be triggered.
     - `gasIncPct` (number, optional): The parameter is used to specify the percentage increase on the current default
       gas. For example, if the current default gas is 100 gwei and `gasIncPct` is set to 20, then the final gas will be 120
       gwei.
@@ -370,6 +374,22 @@ flatDirectory.download("example.txt", {
         console.log("Download finish.");
     }
 });
+```
+
+### fetchHashes
+
+**Description**: Retrieve the chunk hashes corresponding to the batch of keys.
+
+**Parameters**
+- `keys` (string[]): The keys to be retrieved.
+
+**Returns**
+- `result` (Promise<Record<string, string[]>>): A Promise that resolves to an object where each key (from the input keys) maps to an array of chunk hashes.
+
+**Example**
+```javascript
+const keys = ["key1", "key2"];
+const result = await flatDirectory.fetchHashes(keys);
 ```
 
 ### setDefault

--- a/src/flatdirectory.js
+++ b/src/flatdirectory.js
@@ -169,19 +169,15 @@ export class FlatDirectory {
         return this.#fetchHashes(fileInfos);
     }
 
-    async #fetchHashes(fileInfos, concurrencyLimit = 5) {
+    async #fetchHashes(fileInfos) {
         const allHashes = {};
 
         const batchArray = [];
         let currentBatch = {};
         let currentChunkCount = 0;
         for (const { key, chunkCount } of fileInfos) {
-            if (chunkCount === 0) {
-                allHashes[key] = [];
-                continue;
-            }
+            allHashes[key] = chunkCount === 0 ? [] : new Array(chunkCount);
 
-            allHashes[key] = new Array(chunkCount);
             for (let i = 0; i < chunkCount; i++) {
                 if (!currentBatch[key]) {
                     currentBatch[key] = [];

--- a/src/flatdirectory.js
+++ b/src/flatdirectory.js
@@ -7,7 +7,7 @@ import {
     MAX_BLOB_COUNT,
     UPLOAD_TYPE_BLOB,
     UPLOAD_TYPE_CALLDATA,
-    MAX_RETRIES,
+    MAX_RETRIES, MAX_CHUNKS,
     FLAT_DIRECTORY_CONTRACT_VERSION_1_0_0
 } from './param';
 import {
@@ -18,14 +18,11 @@ import {
     stringToHex, isNodejs,
     retry, getContentChunk,
     getUploadInfo, getChunkCounts,
+    getChunkHashes,
 } from "./utils";
 
 import workerpool from 'workerpool';
 const pool = workerpool.pool(__dirname + '/worker.cjs.js');
-
-const REMOVE_FAIL = -1;
-const REMOVE_NORMAL = 0;
-const REMOVE_SUCCESS = 1;
 
 const GALILEO_CHAIN_ID = 3334;
 
@@ -82,6 +79,11 @@ export class FlatDirectory {
             throw new Error("FlatDirectory: The current SDK does not support this contract. Please switch to version 2.0.0.");
         }
         this.#isSupportBlob = supportBlob;
+    }
+
+    isSupportBlob() {
+        this.#checkAddress();
+        return this.#isSupportBlob;
     }
 
     async deploy() {
@@ -156,6 +158,66 @@ export class FlatDirectory {
         cb.onFinish();
     }
 
+    async fetchHashes(keys) {
+        if (!keys || !Array.isArray(keys)) {
+            throw new Error('Invalid keys.');
+        }
+
+        // get file chunks
+        const contract = new ethers.Contract(this.#contractAddr, FlatDirectoryAbi, this.#wallet);
+        const fileInfos = await getChunkCounts(contract, keys, this.#retries);
+        return this.#fetchHashes(fileInfos);
+    }
+
+    async #fetchHashes(fileInfos, concurrencyLimit = 5) {
+        const allHashes = {};
+
+        const batchArray = [];
+        let currentBatch = {};
+        let currentChunkCount = 0;
+        for (const { key, chunkCount } of fileInfos) {
+            if (chunkCount === 0) {
+                allHashes[key] = [];
+                continue;
+            }
+
+            allHashes[key] = new Array(chunkCount);
+            for (let i = 0; i < chunkCount; i++) {
+                if (!currentBatch[key]) {
+                    currentBatch[key] = [];
+                }
+                currentBatch[key].push(i);
+                currentChunkCount++;
+                // If the batch reaches the chunk limit, create a task
+                if (currentChunkCount === MAX_CHUNKS) {
+                    batchArray.push(currentBatch);
+                    currentBatch = {};
+                    currentChunkCount = 0;
+                }
+            }
+        }
+        if (Object.keys(currentBatch).length > 0) {
+            batchArray.push(currentBatch);
+        }
+
+        // request
+        if (batchArray.length > 0) {
+            const contract = new ethers.Contract(this.#contractAddr, FlatDirectoryAbi, this.#wallet);
+            const hashResults = await Promise.all(batchArray.map(batch => {
+                const fileChunksArray = Object.keys(batch).map(name => ({
+                    name,
+                    chunkIds: batch[name]
+                }));
+                return getChunkHashes(contract, fileChunksArray, this.#retries);
+            }));
+            // Combine results
+            hashResults.flat().forEach(({name, chunkId, hash}) => {
+                allHashes[name][chunkId] = hash;
+            });
+        }
+        return allHashes;
+    }
+
     async estimateCost(request) {
         this.#checkAddress();
 
@@ -194,6 +256,8 @@ export class FlatDirectory {
         }
     }
 
+
+
     // private method
     #checkAddress() {
         if (!this.#contractAddr) {
@@ -202,7 +266,7 @@ export class FlatDirectory {
     }
 
     async #estimateCostByBlob(request) {
-        const {key, content, gasIncPct = 0} = request;
+        let {key, content, chunkHashes, gasIncPct = 0} = request;
 
         if (!this.#isSupportBlob) {
             throw new Error(`FlatDirectory: The contract does not support blob upload!`);
@@ -222,24 +286,25 @@ export class FlatDirectory {
             throw new Error("FlatDirectory: This file does not support blob upload!");
         }
 
+        // Get old chunk hashes, If the chunk hashes is not passed, it is obtained here
+        if (!chunkHashes) {
+            const hashes = await this.#fetchHashes([{ key, chunkCount: oldChunkCount }]);
+            chunkHashes = hashes[key];
+        }
+
         let totalGasCost = 0n;
         let totalStorageCost = 0n;
         let gasLimit = 0;
         // send
         for (let i = 0; i < blobLength; i += MAX_BLOB_COUNT) {
-            const {
-                blobArr,
-                chunkIdArr,
-                chunkSizeArr,
-                blobHashRequestArr
-            } = await this.#getBlobInfo(fileContract, content, hexName, i);
+            const { blobArr, chunkIdArr, chunkSizeArr } = await this.#getBlobInfo(fileContract, content, hexName, i);
 
             let blobHashArr;
             // check change
-            if (chunkIdArr[0] < oldChunkCount) {
+            if (i + blobArr.length <= chunkHashes.length) {
                 blobHashArr = await this.#getBlobHashes(blobArr);
-                const isChange = await retry(() => this.#checkChange(blobHashArr, blobHashRequestArr), this.#retries);
-                if (!isChange) {
+                const cloudHashArr = chunkHashes.slice(i, i + blobHashArr.length);
+                if (JSON.stringify(blobHashArr) === JSON.stringify(cloudHashArr)) {
                     continue;
                 }
             }
@@ -269,7 +334,7 @@ export class FlatDirectory {
     }
 
     async #estimateCostByCallData(request) {
-        const {key, content, gasIncPct = 0} = request;
+        let {key, content, chunkHashes, gasIncPct = 0} = request;
 
         const {chunkDataSize, chunkLength} = this.#getChunkLength(content);
         if (chunkDataSize === -1) {
@@ -283,6 +348,11 @@ export class FlatDirectory {
             throw new Error(`FlatDirectory: This file does not support calldata upload!`);
         }
 
+        // Get old chunk hashes, If the chunk hashes is not passed, it is obtained here
+        if (!chunkHashes) {
+            const hashes = await this.#fetchHashes([{ key, chunkCount: oldChunkCount }]);
+            chunkHashes = hashes[key];
+        }
 
         let totalStorageCost = 0n;
         let totalGasCost = 0n;
@@ -291,12 +361,8 @@ export class FlatDirectory {
             const chunk = await getContentChunk(content, i * chunkDataSize, (i + 1) * chunkDataSize);
 
             // check is change
-            if (i < oldChunkCount) {
-                const localHash = ethers.keccak256(chunk);
-                const hash = await retry(() => fileContract.getChunkHash(hexName, i), this.#retries);
-                if (localHash === hash) {
-                    continue;
-                }
+            if (i < chunkHashes.length && ethers.keccak256(chunk) === chunkHashes[i]) {
+                continue;
             }
 
             // get cost, Galileo need stake
@@ -321,7 +387,7 @@ export class FlatDirectory {
         let totalUploadSize = 0;
         let totalStorageCost = 0n;
 
-        const {key, content, callback, gasIncPct} = request;
+        let {key, content, callback, chunkHashes, gasIncPct} = request;
         if (!this.#isSupportBlob) {
             callback.onFail(new Error(`FlatDirectory: The contract does not support blob upload!`));
             callback.onFinish(totalUploadChunks, totalUploadSize, totalStorageCost);
@@ -344,28 +410,29 @@ export class FlatDirectory {
             return;
         }
 
-        const clearState = await retry(() => this.#clearOldFile(hexName, blobLength, oldChunkCount), this.#retries);
-        if (clearState === REMOVE_FAIL) {
+        const clearState = await retry(() => this.#clearOldFile(fileContract, hexName, blobLength, oldChunkCount), this.#retries);
+        if (!clearState) {
             callback.onFail(new Error(`FlatDirectory: Failed to delete old data!`));
             callback.onFinish(totalUploadChunks, totalUploadSize, totalStorageCost);
             return;
         }
 
+        // Get old chunk hashes, If the chunk hashes is not passed, it is obtained here
+        if (!chunkHashes) {
+            const hashes = await this.#fetchHashes([{ key, chunkCount: oldChunkCount }]);
+            chunkHashes = hashes[key];
+        }
+
         // send
         for (let i = 0; i < blobLength; i += MAX_BLOB_COUNT) {
-            const {
-                blobArr,
-                chunkIdArr,
-                chunkSizeArr,
-                blobHashRequestArr
-            } = await this.#getBlobInfo(fileContract, content, hexName, i);
+            const { blobArr, chunkIdArr, chunkSizeArr } = await this.#getBlobInfo(fileContract, content, hexName, i);
             const blobCommitmentArr = await this.#getBlobCommitments(blobArr);
 
             // check change
-            if (clearState === REMOVE_NORMAL) {
-                const blobHashArr = this.#getHashes(blobCommitmentArr);
-                const isChange = await retry(() => this.#checkChange(blobHashArr, blobHashRequestArr), this.#retries);
-                if (!isChange) {
+            if (i + blobArr.length <= chunkHashes.length) {
+                const localHashArr = this.#getHashes(blobCommitmentArr);
+                const cloudHashArr = chunkHashes.slice(i, i + localHashArr.length);
+                if (JSON.stringify(localHashArr) === JSON.stringify(cloudHashArr)) {
                     callback.onProgress(chunkIdArr[chunkIdArr.length - 1], blobLength, false);
                     continue;
                 }
@@ -393,7 +460,7 @@ export class FlatDirectory {
         let totalUploadSize = 0;
         let totalStorageCost = 0n;
 
-        const {key, content, callback, gasIncPct} = request;
+        let {key, content, callback, chunkHashes, gasIncPct} = request;
         const {chunkDataSize, chunkLength} = this.#getChunkLength(content);
         if (chunkDataSize === -1) {
             callback.onFail(new Error(`FlatDirectory: Invalid upload content!`));
@@ -411,24 +478,26 @@ export class FlatDirectory {
         }
 
         // check old data
-        const clearState = await retry(() => this.#clearOldFile(hexName, chunkLength, oldChunkCount), this.#retries);
-        if (clearState === REMOVE_FAIL) {
+        const clearState = await retry(() => this.#clearOldFile(fileContract, hexName, chunkLength, oldChunkCount), this.#retries);
+        if (!clearState) {
             callback.onFail(new Error(`FlatDirectory: Failed to delete old data!`));
             callback.onFinish(totalUploadChunks, totalUploadSize, totalStorageCost);
             return;
+        }
+
+        // Get old chunk hashes, If the chunk hashes is not passed, it is obtained here
+        if (!chunkHashes) {
+            const hashes = await this.#fetchHashes([{ key, chunkCount: oldChunkCount }]);
+            chunkHashes = hashes[key];
         }
 
         for (let i = 0; i < chunkLength; i++) {
             const chunk = await getContentChunk(content, i * chunkDataSize, (i + 1) * chunkDataSize);
 
             // check is change
-            if (clearState === REMOVE_NORMAL) {
-                const localHash = ethers.keccak256(chunk);
-                const hash = await retry(() => fileContract.getChunkHash(hexName, i), this.#retries);
-                if (localHash === hash) {
-                    callback.onProgress(i, chunkLength, false);
-                    continue;
-                }
+            if (i < chunkHashes.length && ethers.keccak256(chunk) === chunkHashes[i]) {
+                callback.onProgress(i, chunkLength, false);
+                continue;
             }
 
             // upload
@@ -477,30 +546,20 @@ export class FlatDirectory {
         return await getUploadInfo(contract, hexName, this.#retries);
     }
 
-    async #clearOldFile(key, chunkLength, oldChunkLength) {
+    async #clearOldFile(contract, key, chunkLength, oldChunkLength) {
         if (oldChunkLength > chunkLength) {
-            // remove
-            const v = await this.remove(key);
-            if (v) {
-                return REMOVE_SUCCESS;
-            } else {
-                return REMOVE_FAIL;
-            }
-        } else if (oldChunkLength === 0) {
-            return REMOVE_SUCCESS;
-        } else {
-            return REMOVE_NORMAL;
-        }
-    }
-
-    async #checkChange(blobHashArr, blobHashRequestArr) {
-        const dataHashArr = await Promise.all(blobHashRequestArr);
-        for (let i = 0; i < blobHashArr.length; i++) {
-            if (blobHashArr[i] !== dataHashArr[i]) {
-                return true;
+            // truncate
+            try {
+                const tx = await contract.truncate(stringToHex(key), chunkLength);
+                console.log(`FlatDirectory: Truncate tx hash is ${tx.hash}`);
+                const receipt = await tx.wait();
+                return receipt?.status === 1;
+            } catch (e) {
+                console.error(`FlatDirectory: Failed to truncate file: ${key}`, e.message);
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
     async #uploadBlob(fileContract, key, hexName, blobArr, blobCommitmentArr, chunkIdArr, chunkSizeArr, cost, gasIncPct) {
@@ -580,7 +639,6 @@ export class FlatDirectory {
 
         const chunkIdArr = [];
         const chunkSizeArr = [];
-        const blobHashRequestArr = [];
         for (let j = 0; j < blobArr.length; j++) {
             chunkIdArr.push(index + j);
             if (j === blobArr.length - 1) {
@@ -588,14 +646,8 @@ export class FlatDirectory {
             } else {
                 chunkSizeArr.push(OP_BLOB_DATA_SIZE);
             }
-            blobHashRequestArr.push(fileContract.getChunkHash(hexName, index + j));
         }
-        return {
-            blobArr,
-            chunkIdArr,
-            chunkSizeArr,
-            blobHashRequestArr
-        }
+        return { blobArr, chunkIdArr, chunkSizeArr }
     }
 
     #getChunkLength(content) {

--- a/src/param/constant.js
+++ b/src/param/constant.js
@@ -34,4 +34,5 @@ export const UPLOAD_TYPE_BLOB = 2;
 
 export const MAX_RETRIES = 3;
 
-export const MAX_CHUNKS = 115;
+// eth-call also consumes gas, so the number of chunks that can be obtained is capped at 3000w gasLimit.
+export const MAX_CHUNKS = 140;

--- a/src/param/constant.js
+++ b/src/param/constant.js
@@ -33,3 +33,5 @@ export const UPLOAD_TYPE_BLOB = 2;
 
 
 export const MAX_RETRIES = 3;
+
+export const MAX_CHUNKS = 115;

--- a/src/param/constant.js
+++ b/src/param/constant.js
@@ -34,5 +34,8 @@ export const UPLOAD_TYPE_BLOB = 2;
 
 export const MAX_RETRIES = 3;
 
-// eth-call also consumes gas, so the number of chunks that can be obtained is capped at 3000w gasLimit.
-export const MAX_CHUNKS = 140;
+/**
+ * eth_call consumes gas, so we need to estimate the maximum number of chunks based on a 30 million gas limit.
+ * Additionally, we need to reserve a portion of the gas for the cost of the request parameters (which can vary dynamically).
+ */
+export const MAX_CHUNKS = 120;

--- a/test.js
+++ b/test.js
@@ -71,6 +71,9 @@ async function FlatDirectoryTest() {
         }
     };
 
+    const hashes = await fd.fetchHashes(["file.jpg", "blobFile.jpg"]);
+    console.log(hashes);
+
     // calldata
     // data
     let request = {
@@ -127,6 +130,7 @@ async function FlatDirectoryTest() {
         key: "blobFile.jpg",
         content: file,
         gasIncPct: 5,
+        chunkHashes: hashes[1],
         callback: uploadCallback
     }
     cost = await fd.estimateCost(request);
@@ -159,5 +163,8 @@ async function FlatDirectoryTest() {
             console.log('download finish');
         }
     });
+
+    const hashes2 = await fd.fetchHashes(["file.jpg", "blobFile.jpg"]);
+    console.log(hashes2);
 }
 FlatDirectoryTest();


### PR DESCRIPTION
Fix issues https://github.com/ethstorage/ethstorage-sdk/issues/21.  use batches to obtain chunk hashe, to reduce network requests and optimize performance.

The current implementation can retrieve the hashes for 115 chunks at once, which allows a website like vitalik.blog, containing over 1000 small files, to reduce the number of hash retrieval requests from 1000+ to just 9.

After the file is uploaded, perform the upload time comparison:

**vitalik.blog**
Total File Count: 984
threadPoolSize: 15

Before optimization:
3.393 minutes
3.341 minutes
3.622 minutes
3.017 minutes
3.289 minutes
average _**3.33**_ minutes

Current:
2.128 minutes
2.161 minutes
2.092 minutes
2.111 minutes
2.123 minutes
average _**2.123**_ minutes

**WechatIMG.jpeg**
File Size: 4.7 MB
Chunk Count: 30

Before optimization:
0.209 minutes
0.205 minutes
0.216 minutes
0.221 minutes
0.218 minutes
average **_0.214_** minutes

Current:
0.176 minutes
0.178 minutes
0.177 minutes
0.175 minutes
0.176 minutes
average **_0.176_** minutes