### PR TITLE
Fix npm package has no dist file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+# .npmignore
+!dist/
+.env
+.idea/
+node_modules/


### PR DESCRIPTION
After the npm version is upgraded, it will obtain the files that need to be filtered from .`gitignore`, resulting in the packaged folder _dist_ not being pulish.