### PR TITLE
Add close function to properly release thread pool resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ const cost = await ethStorage.estimateCost(key, data);
 console.log(`Gas Cost: ${cost.gasCost}, Storage Cost: ${cost.storageCost}`);
 ```
 
+### close
+
+Call the `close` function after completing the operation to properly release resources.
+
+```javascript
+const es = await EthStorage.create({
+    rpc: rpc,
+    ethStorageRpc: ethStorageRpc,
+    privateKey: privateKey,
+});
+
+// Use EthStorage
+await es.methodName();  // methodName() is just an example, replace it with the actual API method
+
+// Close when done
+await es.close();
+```
 
 ## FlatDirectory
 
@@ -271,4 +288,24 @@ const request = {
     type: 2
 }
 const cost = await flatDirectory.estimateCost(request);
+```
+
+
+### close
+
+Call the `close` function after completing the operation to properly release resources.
+
+```javascript
+const flatDirectory = await FlatDirectory.create({
+    rpc: rpc,
+    ethStorageRpc: ethStorageRpc,
+    privateKey: privateKey,
+    address: address,
+});
+
+// Use flatDirectory
+await flatDirectory.methodName();  // methodName() is just an example, replace it with the actual API method
+
+// Close when done
+await flatDirectory.close();
 ```

--- a/spec.md
+++ b/spec.md
@@ -53,6 +53,7 @@ data of arbitrary size.
 | write        | Asynchronously write data                                      |
 | read         | Asynchronously read data                                       |
 | writeBlobs   | Batch upload blob data to the EthStorage network               |
+| close        | Release resources used by the EthStorage instance              |
 
 ## FlatDirectory Class
 
@@ -65,6 +66,7 @@ data of arbitrary size.
 | download     | Asynchronously download data                                   |
 | fetchHashes  | Get chunk hashes of data in batches                            |
 | setDefault   | Set the default file for FlatDirectory                         |
+| close        | Release resources used by the FlatDirectory instance           |
 
 <p id="EthStorage"></p>
 
@@ -174,6 +176,20 @@ const data = await ethStorage.read("example.txt");
 const keys = ["key1", "key2", "key3"];
 const dataBlobs = [Buffer.from("test data 1"), Buffer.from("test data 2"), Buffer.from("test data 3")];
 const result = await ethStorage.writeBlobs(keys, dataBlobs);
+```
+
+### close
+**Description**: Release resources used by the EthStorage instance.
+
+**Parameters**  
+_None_
+
+**Returns**
+- `result` (Promise<void>): A Promise that resolves when the instance is successfully closed.
+
+**Example**
+```javascript
+await ethStorage.close();
 ```
 
 <p id="FlatDirectory"></p>
@@ -428,6 +444,20 @@ const status = await flatDirectory.setDefault(defaultFile);
 ```
 
 <p id="Version"></p>
+
+### close
+**Description**: Release resources used by the FlatDirectory instance.
+
+**Parameters**  
+_None_
+
+**Returns**
+- `result` (Promise<void>): A Promise that resolves when the instance is successfully closed.
+
+**Example**
+```javascript
+await flatDirectory.close();
+```
 
 # 5. Version History
 

--- a/src/ethstorage.ts
+++ b/src/ethstorage.ts
@@ -61,7 +61,7 @@ export class EthStorage {
         ]);
 
         const blobs = encodeOpBlobs(data);
-        const blobHash = this._blobUploader.computeVersionedHashForBlob(blobs[0]);
+        const blobHash = await this._blobUploader.computeVersionedHashForBlob(blobs[0]);
         const gasLimit = await contract["putBlob"].estimateGas(hexKey, 0, data.length, {
             value: storageCost,
             blobVersionedHashes: [blobHash]
@@ -168,6 +168,12 @@ export class EthStorage {
             console.error(`EthStorage: Put blobs failed!`, (e as Error).message);
         }
         return { hash: '0x', success: false };
+    }
+
+    async close() {
+        if (this.blobUploader) {
+            await this.blobUploader.close();
+        }
     }
 
     // get

--- a/src/flatdirectory.ts
+++ b/src/flatdirectory.ts
@@ -195,6 +195,11 @@ export class FlatDirectory {
         }
     }
 
+    async close() {
+        if (this.blobUploader) {
+            await this.blobUploader.close();
+        }
+    }
 
 
     // private method

--- a/src/utils/uploader.ts
+++ b/src/utils/uploader.ts
@@ -122,4 +122,8 @@ export class BlobUploader {
         const commitments = await this.computeCommitmentsForBlobs(blobs);
         return truncateCommitmentHashes(commitments);
     }
+
+    async close(): Promise<void> {
+        await this.kzg.close();
+    }
 }

--- a/test.js
+++ b/test.js
@@ -47,6 +47,7 @@ async function EthStorageTest() {
     // read
     buff = await es.read('key2');
     console.log(Buffer.from(buff).toString());
+    await es.close();
 
     // only read
     const readEs = await EthStorage.create({
@@ -57,6 +58,7 @@ async function EthStorageTest() {
     const wallet = new ethers.Wallet(privateKey);
     buff = await readEs.read('key2', DecodeType.OptimismCompact, wallet.address);
     console.log(Buffer.from(buff).toString());
+    await readEs.close();
 }
 
 async function FlatDirectoryTest() {
@@ -177,6 +179,8 @@ async function FlatDirectoryTest() {
     const hashes2 = await fd.fetchHashes(["file.jpg", "blobFile.jpg"]);
     console.log("get hashes", hashes2);
 
+    await fd.close();
+
     console.log("only download")
     const downloadFd = await FlatDirectory.create({
         ethStorageRpc: 'https://rpc.beta.testnet.l2.ethstorage.io:9596',
@@ -193,6 +197,8 @@ async function FlatDirectoryTest() {
             console.log('download finish');
         }
     });
+
+    await downloadFd.close();
 }
 
 async function main() {


### PR DESCRIPTION
This PR introduces the close function to release resources properly after using the SDK. Since the SDK now utilizes a thread pool for KZG computations, it's necessary to explicitly close the thread pool after completing operations to prevent resource leaks.