### PR TITLE
Rename commitment-hash functions for clarity

### DIFF
--- a/src/ethstorage.ts
+++ b/src/ethstorage.ts
@@ -61,7 +61,7 @@ export class EthStorage {
         ]);
 
         const blobs = encodeOpBlobs(data);
-        const blobHash = await this._blobUploader.computeVersionedHashForBlob(blobs[0]);
+        const blobHash = await this._blobUploader.computeEthStorageHashForBlob(blobs[0]);
         const gasLimit = await contract["putBlob"].estimateGas(hexKey, 0, data.length, {
             value: storageCost,
             blobVersionedHashes: [blobHash]

--- a/src/flatdirectory.ts
+++ b/src/flatdirectory.ts
@@ -16,7 +16,7 @@ import {
     stringToHex,
     retry, getContentChunk,
     getUploadInfo, getChunkCounts,
-    getChunkHashes, truncateCommitmentHashes,
+    getChunkHashes, convertToEthStorageHashes,
 } from "./utils";
 
 const defaultCallback: DownloadCallback = {
@@ -285,7 +285,7 @@ export class FlatDirectory {
             let blobHashArr: string[] | null = null;
             // check change
             if (i + blobArr.length <= chunkHashes.length) {
-                blobHashArr = await this._blobUploader.computeVersionedHashesForBlobs(blobArr);
+                blobHashArr = await this._blobUploader.computeEthStorageHashesForBlobs(blobArr);
                 const cloudHashArr = chunkHashes.slice(i, i + blobHashArr.length);
                 if (JSON.stringify(blobHashArr) === JSON.stringify(cloudHashArr)) {
                     continue;
@@ -298,7 +298,7 @@ export class FlatDirectory {
             totalStorageCost += value;
             // gas cost
             if (gasLimit === 0n) {
-                blobHashArr = blobHashArr || await this._blobUploader.computeVersionedHashesForBlobs(blobArr);
+                blobHashArr = blobHashArr || await this._blobUploader.computeEthStorageHashesForBlobs(blobArr);
                 gasLimit = await retry(() => fileContract["writeChunks"].estimateGas(hexName, chunkIdArr, chunkSizeArr, {
                     value: value,
                     blobVersionedHashes: blobHashArr
@@ -414,7 +414,7 @@ export class FlatDirectory {
 
             // check change
             if (i + blobArr.length <= chunkHashes.length) {
-                const localHashArr = truncateCommitmentHashes(blobCommitmentArr);
+                const localHashArr = convertToEthStorageHashes(blobCommitmentArr);
                 const cloudHashArr = chunkHashes.slice(i, i + localHashArr.length);
                 if (JSON.stringify(localHashArr) === JSON.stringify(cloudHashArr)) {
                     callback.onProgress!(chunkIdArr[chunkIdArr.length - 1], blobLength, false);

--- a/src/utils/uploader.ts
+++ b/src/utils/uploader.ts
@@ -1,6 +1,6 @@
 import { ethers } from "ethers";
 import { Mutex } from 'async-mutex';
-import { computeVersionedCommitmentHash, truncateCommitmentHash, truncateCommitmentHashes } from "./util";
+import { computeVersionedCommitmentHash, convertToEthStorageHash, convertToEthStorageHashes } from "./util";
 import { KZG } from "js-kzg";
 
 // blob gas price
@@ -113,14 +113,14 @@ export class BlobUploader {
         return await this.kzg.computeCommitmentBatch(blobs);
     }
 
-    async computeVersionedHashForBlob(blob: Uint8Array): Promise<string> {
+    async computeEthStorageHashForBlob(blob: Uint8Array): Promise<string> {
         const commit = await this.kzg.computeCommitment(blob);
-        return truncateCommitmentHash(commit);
+        return convertToEthStorageHash(commit);
     }
 
-    async computeVersionedHashesForBlobs(blobs: Uint8Array[]): Promise<string[]> {
+    async computeEthStorageHashesForBlobs(blobs: Uint8Array[]): Promise<string[]> {
         const commitments = await this.computeCommitmentsForBlobs(blobs);
-        return truncateCommitmentHashes(commitments);
+        return convertToEthStorageHashes(commitments);
     }
 
     async close(): Promise<void> {

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -45,15 +45,15 @@ export function computeVersionedCommitmentHash(commitment: Uint8Array): Uint8Arr
     return computedVersionedHash;
 }
 
-export function truncateCommitmentHash(commitment: Uint8Array): string {
+export function convertToEthStorageHash(commitment: Uint8Array): string {
     const localHash = computeVersionedCommitmentHash(commitment);
     const hash = new Uint8Array(32);
     hash.set(localHash.subarray(0, 32 - 8));
     return ethers.hexlify(hash);
 }
 
-export function truncateCommitmentHashes(commitments: Uint8Array[]): string[] {
-    return commitments.map(commitment => truncateCommitmentHash(commitment));
+export function convertToEthStorageHashes(commitments: Uint8Array[]): string[] {
+    return commitments.map(commitment => convertToEthStorageHash(commitment));
 }
 
 export async function retry<T>(fn: (...args: any[]) => Promise<T>, retries: number, ...args: any[]): Promise<T> {


### PR DESCRIPTION
This PR improves the naming of several commitment-hash functions to better reflect their actual behavior and enhance code readability.