### PR TITLE
Update js-kzg to Latest Version for Improved Performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "async-mutex": "^0.5.0",
     "dotenv": "^16.4.5",
     "ethers": "^6.13.1",
-    "js-kzg": "^1.0.1"
+    "js-kzg": "^1.0.4"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -570,15 +570,21 @@ joycon@^3.1.1:
   resolved "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
-js-kzg@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/js-kzg/-/js-kzg-1.0.1.tgz#6bd678610cd1b0e71e560221c28be015bce4cd15"
-  integrity sha512-P7QJU1EJlf8qe2/2iCaL0i7DmVwf6cjHWvknV4JmcP/KYXXGX4BQ54X3PIO5PfaS24tc6IKSFic806O5DFMoLg==
+js-kzg@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/js-kzg/-/js-kzg-1.0.4.tgz#5dba2c7a157c3848178592b6666afc06144313ff"
+  integrity sha512-rn5zL47kaWeMJ8CvUCS+nIYNaJPvArUzubeYP5ZznucVR7qXrkE/GgRCmxX2j3xDlkOYbZobWEOvvkv4JoE3ew==
   dependencies:
     "@paulmillr/trusted-setups" "^0.1.2"
     comlink "^4.4.2"
+    kzg-wasm "^0.5.0"
     micro-eth-signer "^0.14.0"
     workerpool "^9.2.0"
+
+kzg-wasm@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/kzg-wasm/-/kzg-wasm-0.5.0.tgz#6540a1417c2c3d359d1df1b5fd3f49f812bc9302"
+  integrity sha512-LK1M0dm62NKEyhaM6S0pMHKzyAB+KySUlbT+z/+N6fZvcg0jEqSAiz6YHPk8MWIadlT0vFx1uT6Pf9dLzhTn4g==
 
 lilconfig@^3.1.1:
   version "3.1.3"


### PR DESCRIPTION
During performance testing, we found that the older version of js-kzg (which uses the micro-eth-signer library) was significantly slower than implementations using the kzg-wasm library in multi-threaded environments. The new version of js-kzg has switched from micro-eth-signer to kzg-wasm.

**Note**: However, due to compatibility issues with multi-threading in browsers when using kzg-wasm, js-kzg still uses micro-eth-signer in browser environments for now.


**Performance Comparison**
**Test**: Re-upload and compare if files have changed after full data upload

#### Dataset: `vitalik.blog`

- **Total files**: 987  
- **Total chunks**: 1295  

| Version | Description | KZG Implementation | Threads | Time |
|---------|-------------|------------------|---------|--------|
| **Old SDK 1** | Old version of `js-kzg` | `micro-eth-signer` | Single-threaded | **27m 59s** |
| **Old SDK 2** | Same version, with multi-threading support | `micro-eth-signer` | Multi-threaded | **5m 41s** |
| **New SDK (This PR)** | Latest `js-kzg` using `kzg-wasm` | `kzg-wasm v0.5` | Multi-threaded | **3m 26s** |
| **ethfs-cli** | Direct integration, no `js-kzg` | `kzg-wasm v0.3` | Multi-threaded | **5m 07s** |


#### Dataset: `Big File`

- **Total files**: 1  
- **Total chunks**: 4130  

| Version | Description | KZG Implementation | Threads | Time |
|---------|-------------|------------------|---------|--------|
| **Old SDK 1** | Old version of `js-kzg` | `micro-eth-signer` | Single-threaded | **2h 41m** |
| **Old SDK 2** | Same version, with multi-threading support | `micro-eth-signer` | Multi-threaded | **56m 51s** |
| **New SDK (This PR)** | Latest `js-kzg` using `kzg-wasm` | `kzg-wasm v0.5` | Multi-threaded | **19m 47s** |
| **ethfs-cli** | Direct integration, no `js-kzg` | `kzg-wasm v0.3` | Multi-threaded | **35m 19s** |

