### PR TITLE
fix(docs): point FlatDirectory link to current path

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ const flatDirectory = await FlatDirectory.create({
 ### deploy
 
 Deploy the implementation
-contract [FlatDirectory](https://github.com/ethstorage/evm-large-storage/blob/master/contracts/examples/FlatDirectory.sol)
+contract [FlatDirectory](https://github.com/ethstorage/evm-large-storage/blob/master/contracts/FlatDirectory.sol)
 for [EIP-5018](https://eips.ethereum.org/EIPS/eip-5018) standard.
 
 ```js


### PR DESCRIPTION
Hey! Replaced outdated reference `contracts/examples/FlatDirectory.sol` with working path `contracts/FlatDirectory.sol`.






