### PR TITLE
deleted extra space in export statement

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
 export * from './util';
-export *  from './blobs';
+export * from './blobs';
 export * from './uploader';
 export * from './web3';


### PR DESCRIPTION
Remove extra whitespace between asterisk and 'from' keyword in the blobs module export statement to maintain consistent code style across the codebase.