### PR TITLE
Fix SDK creation failure, worker not released

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethstorage-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "eip-4844 blobs upload sdk",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",

--- a/src/flatdirectory.ts
+++ b/src/flatdirectory.ts
@@ -76,6 +76,9 @@ export class FlatDirectory {
             })
         ]);
         if (contractVersion !== FLAT_DIRECTORY_CONTRACT_VERSION_1_1_0) {
+            // Release the worker, otherwise the SDK creation fails, but the worker still exists.
+            await this.close();
+
             let sdkSuggestion: string;
             if (contractVersion === FLAT_DIRECTORY_CONTRACT_VERSION_1_0_0) {
                 sdkSuggestion = "SDK v3.x";


### PR DESCRIPTION
Old version contracts using the SDK will throw an exception, but the worker thread created in the SDK is not released, causing the console cursor to flash continuously.