### PR TITLE
fix txReceipt not found

### DIFF
--- a/src/flatdirectory.ts
+++ b/src/flatdirectory.ts
@@ -674,10 +674,7 @@ export class FlatDirectory {
         callback: UploadCallback
     ): Promise<ethers.TransactionResponse> {
         const hexData = ethers.hexlify(chunk);
-        const cost = chunk.length > 24 * 1024 - 326 ? BigInt(Math.floor((chunk.length + 326) / 1024 / 24)) : 0n;
-        const tx = await fileContract["writeChunkByCalldata"].populateTransaction(hexName, chunkId, hexData, {
-            value: ethers.parseEther(cost.toString())
-        });
+        const tx = await fileContract["writeChunkByCalldata"].populateTransaction(hexName, chunkId, hexData);
         // Increase % if user requests it
         if (gasIncPct > 0) {
             // Fetch the current gas price and increase it

--- a/src/utils/uploader.ts
+++ b/src/utils/uploader.ts
@@ -105,10 +105,7 @@ export class BlobUploader {
     }
 
     async getTransactionResult(hash: string): Promise<UploadResult> {
-        const txResponse = await this.provider.getTransaction(hash);
-        if (!txResponse) throw new Error("tx not found");
-
-        const txReceipt = await txResponse.wait();
+        const txReceipt = await this.provider.waitForTransaction(hash);
         const txCost = calcTxCost(txReceipt);
         return {
             txCost,


### PR DESCRIPTION
Fixes the issue where "public RPC or load balancing cluster" causes `provider.getTransaction` to fail to retrieve data.